### PR TITLE
Update rust.yml to install dependencies before build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install Dependencies before building
+      run: apt-get update && apt-get install libpq5 libsasl2-dev zlib1g -y
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
Update rust.yml to install dependencies before build.

To correct build the rust software, it is necessary to add some linux packages. The following command was added to the rust.yml:

apt-get update && apt-get install libpq5 libsasl2-dev zlib1g -y